### PR TITLE
Fix Slack notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix the Slack notifier to correctly send the request to the Slack webhook
+
 ## [0.5.2] - 2016-06-09
 ### Fixed
 - Fix fatal error on new user registration

--- a/src/Badger/GameBundle/Notifier/SlackNotifier.php
+++ b/src/Badger/GameBundle/Notifier/SlackNotifier.php
@@ -3,7 +3,10 @@
 namespace Badger\GameBundle\Notifier;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Slack implementation of the NotifierInterface.
@@ -18,12 +21,17 @@ class SlackNotifier implements NotifierInterface
     /** @var string */
     private $webhookUrl;
 
+    /** @var LoggerInterface */
+    private $logger;
+
     /**
-     * @param string $webhookUrl
+     * @param string          $webhookUrl
+     * @param LoggerInterface $logger
      */
-    public function __construct($webhookUrl)
+    public function __construct($webhookUrl, LoggerInterface $logger)
     {
         $this->webhookUrl = $webhookUrl;
+        $this->logger = $logger;
     }
 
     /**
@@ -40,6 +48,27 @@ class SlackNotifier implements NotifierInterface
         );
 
         $promise = $client->sendAsync($request, ['timeout' => 10]);
+
+        $promise->then(
+            function (ResponseInterface $res) use ($data) {
+                $this->logger->info(
+                    sprintf(
+                        'Request to SLACK webhook OK [%s] with data: %s',
+                        $res->getStatusCode(),
+                        json_encode($data)
+                    )
+                );
+            },
+            function (RequestException $e) {
+                $this->logger->error(
+                    sprintf(
+                        'Request to SLACK webhook FAILED with message: %s',
+                        $e->getMessage()
+                    )
+                );
+            }
+        );
+
         $promise->wait(false);
     }
 }

--- a/src/Badger/GameBundle/Notifier/SlackNotifier.php
+++ b/src/Badger/GameBundle/Notifier/SlackNotifier.php
@@ -39,6 +39,7 @@ class SlackNotifier implements NotifierInterface
             json_encode($data)
         );
 
-        $client->sendAsync($request, ['timeout' => 2]);
+        $promise = $client->sendAsync($request, ['timeout' => 10]);
+        $promise->wait(false);
     }
 }

--- a/src/Badger/GameBundle/Resources/config/services.yml
+++ b/src/Badger/GameBundle/Resources/config/services.yml
@@ -16,3 +16,4 @@ services:
         class: '%badger.notifier.slack.class%'
         arguments:
             - '%slack_webhook_url%'
+            - '@logger'


### PR DESCRIPTION
The SlackNotifier was not pinging the Slack webhook url.
We need to wait for the promise otherwise the PHP process stops and kills the request.

We can bypass the `wait()` if we run this code in a kind of daemon, which is not the case here since it's an EventListener so in the main PHP Process.

Cf.: http://docs.guzzlephp.org/en/latest/faq.html?highlight=wait